### PR TITLE
Enable product/trigger tables and symptom severity logging

### DIFF
--- a/database.py
+++ b/database.py
@@ -130,20 +130,98 @@ class Database:
             logger.error(f"Error updating reminder time for user {telegram_id}: {e}")
             raise
 
-    async def log_product(self, user_id: int, product_name: str) -> Dict[str, Any]:
+    async def get_products(self, user_id: int) -> List[Dict[str, Any]]:
+        """Retrieve products for a user including global ones."""
+        try:
+            user = await self.get_user_by_telegram_id(user_id)
+            if not user:
+                return []
+            response = (
+                self.client.table('products')
+                .select('*')
+                .or_(f'user_id.eq.{user["id"]},is_global.eq.true')
+                .execute()
+            )
+            return response.data
+        except Exception as e:
+            logger.error(f"Error retrieving products for user {user_id}: {e}")
+            return []
+
+    async def add_product(
+        self, user_id: int, name: str, product_type: Optional[str] = None, is_global: bool = False
+    ) -> Dict[str, Any]:
+        """Add a product definition."""
+        try:
+            user = await self.get_user_by_telegram_id(user_id)
+            if not user:
+                raise ValueError(f"User {user_id} not found")
+            data = {
+                'user_id': user['id'],
+                'name': name,
+                'type': product_type,
+                'is_global': is_global,
+            }
+            response = self.client.table('products').insert(data).execute()
+            return response.data[0]
+        except Exception as e:
+            logger.error(f"Error adding product for user {user_id}: {e}")
+            raise
+
+    async def get_triggers(self, user_id: int) -> List[Dict[str, Any]]:
+        """Retrieve triggers for a user including global ones."""
+        try:
+            user = await self.get_user_by_telegram_id(user_id)
+            if not user:
+                return []
+            response = (
+                self.client.table('triggers')
+                .select('*')
+                .or_(f'user_id.eq.{user["id"]},is_global.eq.true')
+                .execute()
+            )
+            return response.data
+        except Exception as e:
+            logger.error(f"Error retrieving triggers for user {user_id}: {e}")
+            return []
+
+    async def add_trigger(
+        self, user_id: int, name: str, emoji: Optional[str] = None, is_global: bool = False
+    ) -> Dict[str, Any]:
+        """Add a trigger definition."""
+        try:
+            user = await self.get_user_by_telegram_id(user_id)
+            if not user:
+                raise ValueError(f"User {user_id} not found")
+            data = {
+                'user_id': user['id'],
+                'name': name,
+                'emoji': emoji,
+                'is_global': is_global,
+            }
+            response = self.client.table('triggers').insert(data).execute()
+            return response.data[0]
+        except Exception as e:
+            logger.error(f"Error adding trigger for user {user_id}: {e}")
+            raise
+
+    async def log_product(
+        self, user_id: int, product_name: str, notes: Optional[str] = None, effect: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Log a product usage."""
         try:
             # Get user
             user = await self.get_user_by_telegram_id(user_id)
             if not user:
                 raise ValueError(f"User {user_id} not found")
-            
+
             product_data = {
                 'user_id': user['id'],
                 'product_name': product_name,
+                'effect': effect,
+                'notes': notes,
                 'logged_at': datetime.utcnow().isoformat()
             }
-            
+
             response = self.client.table('product_logs').insert(product_data).execute()
             logger.info(f"Logged product for user {user_id}: {product_name}")
             return response.data[0]
@@ -152,17 +230,20 @@ class Database:
             logger.error(f"Error logging product for user {user_id}: {e}")
             raise
 
-    async def log_trigger(self, user_id: int, trigger_name: str) -> Dict[str, Any]:
+    async def log_trigger(
+        self, user_id: int, trigger_name: str, notes: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Log a trigger."""
         try:
             # Get user
             user = await self.get_user_by_telegram_id(user_id)
             if not user:
                 raise ValueError(f"User {user_id} not found")
-            
+
             trigger_data = {
                 'user_id': user['id'],
                 'trigger_name': trigger_name,
+                'notes': notes,
                 'logged_at': datetime.utcnow().isoformat()
             }
             
@@ -174,7 +255,9 @@ class Database:
             logger.error(f"Error logging trigger for user {user_id}: {e}")
             raise
 
-    async def log_symptom(self, user_id: int, symptom_name: str) -> Dict[str, Any]:
+    async def log_symptom(
+        self, user_id: int, symptom_name: str, severity: int, notes: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Log a symptom."""
         try:
             # Get user
@@ -185,6 +268,8 @@ class Database:
             symptom_data = {
                 'user_id': user['id'],
                 'symptom_name': symptom_name,
+                'severity': severity,
+                'notes': notes,
                 'logged_at': datetime.utcnow().isoformat(),
             }
 

--- a/seed.sql
+++ b/seed.sql
@@ -9,13 +9,26 @@ INSERT INTO symptoms (name, is_custom) VALUES
   ('Bumps', false)
 ON CONFLICT (name) DO NOTHING;
 
+-- Products
+INSERT INTO products (name, is_global) VALUES
+  ('Cicaplast', true),
+  ('Azelaic Acid', true),
+  ('Enstilar', true),
+  ('Cerave Moisturizer', true),
+  ('Sunscreen', true),
+  ('Retinol', true),
+  ('Niacinamide', true),
+  ('Salicylic Acid', true)
+ON CONFLICT (name) DO NOTHING;
+
 -- Triggers
-INSERT INTO triggers (name, is_custom) VALUES
-  ('Sun Exposure', false),
-  ('Stress', false),
-  ('New Product', false),
-  ('Diet Change', false),
-  ('Weather Change', false)
+INSERT INTO triggers (name, is_global) VALUES
+  ('Sun exposure', true),
+  ('Stress', true),
+  ('Hot weather', true),
+  ('Sweating', true),
+  ('Spicy food', true),
+  ('Alcohol', true)
 ON CONFLICT (name) DO NOTHING;
 
 -- Conditions


### PR DESCRIPTION
## Summary
- introduce `products` and `triggers` tables plus expand log tables with notes/effect fields and update timestamps
- add database helpers to manage products and triggers and log symptoms with severity
- update bot to load options from database, support custom entries, and request symptom severity ratings
- seed default products and triggers for new tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f0d57e9e4832e8edd2c1395ed9edd