### PR TITLE
feat: add user logs endpoint with auth

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,13 +1,16 @@
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from typing import List
+from typing import List, Dict, Any, Optional
 import os
 import asyncio
 from dotenv import load_dotenv
 import logging
 from bot import SkinHealthBot
 from telegram import Update
+import hmac
+import hashlib
+from urllib.parse import parse_qsl
 
 # Load environment variables
 load_dotenv()
@@ -24,6 +27,40 @@ app = FastAPI(title="Skin Health Tracker Bot", version="1.0.0")
 
 # Initialize bot
 bot = SkinHealthBot()
+
+
+def verify_telegram_auth(init_data: str) -> Optional[Dict[str, Any]]:
+    """Verify Telegram WebApp authentication data.
+
+    Returns the parsed data if valid, otherwise ``None``.
+    """
+    try:
+        data = dict(parse_qsl(init_data, keep_blank_values=True))
+        hash_value = data.pop("hash", None)
+        if not hash_value:
+            return None
+        data_check_string = "\n".join(f"{k}={v}" for k, v in sorted(data.items()))
+        secret_key = hashlib.sha256(bot.token.encode()).digest()
+        calculated_hash = hmac.new(
+            secret_key, data_check_string.encode(), hashlib.sha256
+        ).hexdigest()
+        if calculated_hash != hash_value:
+            return None
+        return data
+    except Exception as e:
+        logger.warning(f"Telegram auth verification failed: {e}")
+        return None
+
+
+async def authenticate_request(request: Request, telegram_id: int) -> Dict[str, Any]:
+    """Validate Telegram auth headers and ensure user matches."""
+    init_data = request.headers.get("X-Telegram-Init-Data")
+    if not init_data:
+        raise HTTPException(status_code=401, detail="Missing auth data")
+    auth_data = verify_telegram_auth(init_data)
+    if not auth_data or str(telegram_id) != auth_data.get("id"):
+        raise HTTPException(status_code=401, detail="Invalid auth data")
+    return auth_data
 
 @app.on_event("startup")
 async def startup_event():
@@ -121,6 +158,29 @@ async def delete_webhook():
     except Exception as e:
         logger.error(f"Error deleting webhook: {e}")
         raise HTTPException(status_code=500, detail="Failed to delete webhook")
+
+
+@app.get("/users/{telegram_id}/logs")
+async def get_user_logs(telegram_id: int, request: Request, days: int = 7):
+    """Return recent logs for the specified user."""
+    await authenticate_request(request, telegram_id)
+    user = await bot.database.get_user_by_telegram_id(telegram_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    logs = await bot.database.get_user_logs(telegram_id, days)
+    return {
+        "products": logs.get("products", []),
+        "triggers": logs.get("triggers", []),
+        "symptoms": [
+            {
+                "symptom_name": log.get("symptom_name"),
+                "severity": log.get("severity"),
+                "logged_at": log.get("logged_at"),
+                "id": log.get("id"),
+            }
+            for log in logs.get("symptoms", [])
+        ],
+    }
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- secure Telegram WebApp requests by verifying init data hash
- add `/users/{telegram_id}/logs` endpoint returning product, trigger and symptom logs with severity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f10940160832e82a675058580c51d