### PR TITLE
Use service key and auto-create photo bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ available via the `/env-check` page):
 
 - **NEXT_PUBLIC_SUPABASE_URL**: Your Supabase project URL
 - **NEXT_PUBLIC_SUPABASE_ANON_KEY**: Supabase anonymous key
+- **SUPABASE_SERVICE_ROLE_KEY**: Supabase service role key for server-side uploads
 - **TELEGRAM_BOT_TOKEN**: Bot token from @BotFather
 - **OPENAI_API_KEY**: OpenAI API key for GPT-4 analysis
 - **BASE_URL**: URL where your bot is hosted
@@ -42,6 +43,7 @@ available via the `/env-check` page):
    # Copy contents of schema.sql into Supabase SQL Editor
    ```
 3. This creates all necessary tables and Row Level Security policies
+4. The application will automatically create the private `skin-photos` bucket and an `uploads` folder for user photos
 
 ### 3. Install Dependencies
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -8,6 +8,8 @@ from database import Database
 async def test_get_user_logs(monkeypatch):
     # Prepare fake supabase client
     supabase_client = MagicMock()
+    supabase_client.storage = MagicMock()
+    supabase_client.storage.get_bucket.return_value = MagicMock()
 
     def make_table_mock(return_data):
         table = MagicMock()
@@ -55,6 +57,8 @@ def anyio_backend():
 @pytest.mark.anyio
 async def test_create_user_with_defaults(monkeypatch):
     supabase_client = MagicMock()
+    supabase_client.storage = MagicMock()
+    supabase_client.storage.get_bucket.return_value = MagicMock()
     table = MagicMock()
     supabase_client.table.return_value = table
     table.select.return_value = table


### PR DESCRIPTION
## Summary
- prefer SUPABASE_SERVICE_ROLE_KEY for storage operations
- auto-create private `skin-photos` bucket with expected settings
- document service role key and automatic bucket setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892d98fc6b0832eae7910c3393bef5d