### PR TITLE
feat: add condition management via telegram

### DIFF
--- a/database.py
+++ b/database.py
@@ -246,6 +246,40 @@ class Database:
             logger.error(f"Error adding trigger for user {user_id}: {e}")
             raise
 
+    async def get_conditions(self, user_id: int) -> List[Dict[str, Any]]:
+        """Retrieve conditions for a user."""
+        try:
+            user = await self.get_user_by_telegram_id(user_id)
+            if not user:
+                return []
+            response = (
+                self.client.table('conditions')
+                .select('*')
+                .eq('user_id', user['id'])
+                .execute()
+            )
+            return response.data
+        except Exception as e:
+            logger.error(f"Error retrieving conditions for user {user_id}: {e}")
+            return []
+
+    async def add_condition(self, user_id: int, name: str, condition_type: str) -> Dict[str, Any]:
+        """Add a condition for a user."""
+        try:
+            user = await self.get_user_by_telegram_id(user_id)
+            if not user:
+                raise ValueError(f"User {user_id} not found")
+            data = {
+                'user_id': user['id'],
+                'name': name,
+                'condition_type': condition_type,
+            }
+            response = self.client.table('conditions').insert(data).execute()
+            return response.data[0]
+        except Exception as e:
+            logger.error(f"Error adding condition for user {user_id}: {e}")
+            raise
+
     async def log_product(
         self, user_id: int, product_name: str, notes: Optional[str] = None, effect: Optional[str] = None
     ) -> Dict[str, Any]:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -78,3 +78,38 @@ async def test_create_user_with_defaults(monkeypatch):
     result = await db.create_user(telegram_id=1, username="test")
     assert result["timezone"] == "UTC"
     assert result["reminder_time"] == "09:00"
+
+
+@pytest.mark.anyio
+async def test_add_and_get_conditions(monkeypatch):
+    supabase_client = MagicMock()
+    supabase_client.storage = MagicMock()
+    supabase_client.storage.get_bucket.return_value = MagicMock()
+    table = MagicMock()
+    supabase_client.table.return_value = table
+    table.insert.return_value = table
+    table.select.return_value = table
+    table.eq.return_value = table
+    table.execute.side_effect = [
+        MagicMock(data=[{"id": 1, "name": "Acne", "condition_type": "existing"}]),
+        MagicMock(data=[{"id": 1, "name": "Acne", "condition_type": "existing"}]),
+    ]
+
+    monkeypatch.setenv('NEXT_PUBLIC_SUPABASE_URL', 'url')
+    monkeypatch.setenv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'key')
+    monkeypatch.setattr('database.create_client', lambda url, key: supabase_client)
+
+    db = Database()
+
+    async def fake_get_user_by_telegram_id(tid):
+        return {'id': 10, 'telegram_id': tid}
+
+    monkeypatch.setattr(db, 'get_user_by_telegram_id', fake_get_user_by_telegram_id)
+
+    result = await db.add_condition(1, 'Acne', 'existing')
+    assert result['name'] == 'Acne'
+    assert table.insert.called
+
+    conditions = await db.get_conditions(1)
+    assert conditions[0]['condition_type'] == 'existing'
+    assert table.select.called


### PR DESCRIPTION
## Summary
- show existing conditions in Telegram settings
- allow users to add conditions with type prompts
- add database helpers and tests for condition handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893dd7abd94832eb82e69fe78522a4d