### PR TITLE
Offload skin image processing to background thread

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -598,7 +598,13 @@ Track consistently for best results! 🌟
 
             # Process the image for KPIs
             try:
-                kpi = process_skin_image(temp_path, str(user_id), image_id, self.database.client)
+                kpi = await asyncio.to_thread(
+                    process_skin_image,
+                    temp_path,
+                    str(user_id),
+                    image_id,
+                    self.database.client,
+                )
             finally:
                 try:
                     os.unlink(temp_path)


### PR DESCRIPTION
## Summary
- process skin images in `handle_photo` via `asyncio.to_thread` to keep event loop responsive.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893e801e5e4832e946eb003c7fa2a25