### PR TITLE
Add conditions table with type support

### DIFF
--- a/seed.sql
+++ b/seed.sql
@@ -32,10 +32,10 @@ INSERT INTO triggers (name, is_global) VALUES
 ON CONFLICT (name) DO NOTHING;
 
 -- Conditions
-INSERT INTO conditions (name) VALUES
-  ('Acne'),
-  ('Rosacea'),
-  ('Eczema'),
-  ('Psoriasis'),
-  ('Sensitive Skin')
-ON CONFLICT (name) DO NOTHING;
+INSERT INTO conditions (name, condition_type) VALUES
+  ('Acne', 'existing'),
+  ('Rosacea', 'existing'),
+  ('Eczema', 'existing'),
+  ('Psoriasis', 'existing'),
+  ('Sensitive Skin', 'existing')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- add dedicated `conditions` table to track whether a condition is existing or developed
- index and secure `conditions` table with row level security policies
- seed default conditions with explicit condition type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689428e3d9a4832eb2a4a0c9b472b382