### PR TITLE
Persist reminders and validate environment config

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -95,6 +95,16 @@ class SkinHealthBot:
         await self._setup_persistent_menu()
         # Initialize reminder scheduler now that bot is available
         self.scheduler = ReminderScheduler(self.bot)
+
+        # Reload any stored reminder schedules so they persist across restarts
+        users = await self.database.get_users_with_reminders()
+        for user in users:
+            reminder_time = user.get("reminder_time")
+            if reminder_time:
+                self.scheduler.schedule_daily_reminder(
+                    user["telegram_id"], reminder_time, user.get("timezone", "UTC")
+                )
+
         logger.info("Bot initialized successfully")
 
     async def shutdown(self):

--- a/database.py
+++ b/database.py
@@ -170,6 +170,19 @@ class Database:
             logger.error(f"Error updating reminder time for user {telegram_id}: {e}")
             raise
 
+    async def get_users_with_reminders(self) -> List[Dict[str, Any]]:
+        """Return all users along with their reminder settings."""
+        try:
+            response = (
+                self.client.table('users')
+                .select('telegram_id, reminder_time, timezone')
+                .execute()
+            )
+            return response.data or []
+        except Exception as e:
+            logger.error(f"Error fetching user reminders: {e}")
+            return []
+
     async def get_products(self, user_id: int) -> List[Dict[str, Any]]:
         """Retrieve products for a user including global ones."""
         try:

--- a/env.py
+++ b/env.py
@@ -1,24 +1,41 @@
 from functools import lru_cache
 import os
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, ValidationError
 
 class Settings(BaseModel):
+    """Application settings loaded from environment variables.
+
+    All fields are required to avoid runtime errors caused by missing
+    configuration.  Validation is performed at startup so the application
+    fails fast with a clear message if any variables are absent.
+    """
+
     model_config = ConfigDict(populate_by_name=True)
-    NEXT_PUBLIC_SUPABASE_URL: str = Field(..., alias='NEXT_PUBLIC_SUPABASE_URL')
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: str = Field(..., alias='NEXT_PUBLIC_SUPABASE_ANON_KEY')
-    TELEGRAM_BOT_TOKEN: str | None = Field(default=None, alias='TELEGRAM_BOT_TOKEN')
-    OPENAI_API_KEY: str | None = Field(default=None, alias='OPENAI_API_KEY')
-    SUPABASE_SERVICE_ROLE_KEY: str | None = Field(default=None, alias='SUPABASE_SERVICE_ROLE_KEY')
-    BASE_URL: str | None = Field(default=None, alias='BASE_URL')
+
+    NEXT_PUBLIC_SUPABASE_URL: str = Field(..., alias="NEXT_PUBLIC_SUPABASE_URL")
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: str = Field(..., alias="NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    TELEGRAM_BOT_TOKEN: str = Field(..., alias="TELEGRAM_BOT_TOKEN")
+    OPENAI_API_KEY: str = Field(..., alias="OPENAI_API_KEY")
+    SUPABASE_SERVICE_ROLE_KEY: str = Field(..., alias="SUPABASE_SERVICE_ROLE_KEY")
+    BASE_URL: str = Field(..., alias="BASE_URL")
 
 @lru_cache()
 def get_settings() -> Settings:
-    data = {k: os.getenv(k) for k in [
-        'NEXT_PUBLIC_SUPABASE_URL',
-        'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-        'TELEGRAM_BOT_TOKEN',
-        'OPENAI_API_KEY',
-        'SUPABASE_SERVICE_ROLE_KEY',
-        'BASE_URL',
-    ]}
-    return Settings(**{k: v for k, v in data.items() if v is not None})
+    """Load and validate settings from the environment."""
+
+    keys = [
+        "NEXT_PUBLIC_SUPABASE_URL",
+        "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        "TELEGRAM_BOT_TOKEN",
+        "OPENAI_API_KEY",
+        "SUPABASE_SERVICE_ROLE_KEY",
+        "BASE_URL",
+    ]
+    data = {k: os.getenv(k) for k in keys}
+    try:
+        return Settings(**data)
+    except ValidationError as e:  # pragma: no cover - trivial
+        missing = ", ".join(err["loc"][0] for err in e.errors())
+        raise RuntimeError(
+            f"Missing required environment variables: {missing}"
+        ) from e

--- a/reminder_scheduler.py
+++ b/reminder_scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
 from types import SimpleNamespace
+import logging
 
 try:  # pragma: no cover - used when APScheduler is available
     from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore
@@ -52,6 +53,7 @@ class ReminderScheduler:
         self.bot = bot
         self.scheduler = AsyncIOScheduler(timezone="UTC")
         self.scheduler.start()
+        self.logger = logging.getLogger(__name__)
 
     def schedule_daily_reminder(self, chat_id: int, reminder_time: str, timezone: str = "UTC") -> None:
         """Schedule or reschedule a user's daily reminder.
@@ -75,6 +77,12 @@ class ReminderScheduler:
             timezone=timezone,
             id=f"reminder_{chat_id}",
             replace_existing=True,
+        )
+        self.logger.info(
+            "Scheduled daily reminder for chat %s at %s (%s)",
+            chat_id,
+            reminder_time,
+            timezone,
         )
 
     async def send_daily_reminder(self, chat_id: int) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,12 @@ import sys, os
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
+
+# Provide default environment variables required by the application. Individual
+# tests may override these as needed using ``monkeypatch``.
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_URL", "url")
+os.environ.setdefault("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "token")
+os.environ.setdefault("OPENAI_API_KEY", "openai")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "service")
+os.environ.setdefault("BASE_URL", "http://localhost")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -113,3 +113,26 @@ async def test_add_and_get_conditions(monkeypatch):
     conditions = await db.get_conditions(1)
     assert conditions[0]['condition_type'] == 'existing'
     assert table.select.called
+
+
+@pytest.mark.anyio
+async def test_get_users_with_reminders(monkeypatch):
+    supabase_client = MagicMock()
+    supabase_client.storage = MagicMock()
+    supabase_client.storage.get_bucket.return_value = MagicMock()
+    table = MagicMock()
+    supabase_client.table.return_value = table
+    table.select.return_value = table
+    table.execute.return_value = MagicMock(data=[{
+        'telegram_id': 1,
+        'reminder_time': '09:00',
+        'timezone': 'UTC'
+    }])
+
+    monkeypatch.setenv('NEXT_PUBLIC_SUPABASE_URL', 'url')
+    monkeypatch.setenv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'key')
+    monkeypatch.setattr('database.create_client', lambda url, key: supabase_client)
+
+    db = Database()
+    users = await db.get_users_with_reminders()
+    assert users[0]['telegram_id'] == 1


### PR DESCRIPTION
## Summary
- validate required environment variables with clear error messages
- reload and schedule saved reminders at bot startup
- add helper for fetching user reminder settings and log scheduled jobs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68994f132288832eaf9db7e8361c73e9