### PR TITLE
Use to_thread for face analysis IO

### DIFF
--- a/api/routers/analysis.py
+++ b/api/routers/analysis.py
@@ -25,9 +25,12 @@ _provider = InsightFaceProvider()
 @router.post("/face/heavy")
 async def analyze_face_heavy(req: FaceHeavyRequest):
     """Run heavy face analysis on an image stored in Supabase."""
+    # TODO: Consider moving this analysis workflow into a worker queue if latency is high.
     try:
-        image_path = download_from_bucket(req.bucket, req.object_path)
-        result = _provider.analyze(image_path)
+        image_path = await asyncio.to_thread(
+            download_from_bucket, req.bucket, req.object_path
+        )
+        result = await asyncio.to_thread(_provider.analyze, image_path)
         result_key = f"{req.object_path}.insightface.json"
         upload_json_to_bucket(req.bucket, result_key, result)
         if req.user_id:

--- a/tests/test_analysis_concurrency.py
+++ b/tests/test_analysis_concurrency.py
@@ -1,0 +1,45 @@
+import asyncio
+import time
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from api.routers.analysis import router
+
+
+@pytest.mark.anyio
+async def test_analyze_face_heavy_concurrent(monkeypatch):
+    app = FastAPI()
+    app.include_router(router)
+
+    def fake_download(bucket: str, obj: str) -> str:
+        time.sleep(0.1)
+        return "/tmp/test.png"
+
+    def fake_analyze(path: str):
+        time.sleep(0.1)
+        return {"faces": [], "face_count": 0}
+
+    def fake_upload(bucket: str, key: str, data: dict) -> None:
+        return None
+
+    monkeypatch.setattr("api.routers.analysis.download_from_bucket", fake_download)
+    monkeypatch.setattr("api.routers.analysis._provider.analyze", fake_analyze)
+    monkeypatch.setattr("api.routers.analysis.upload_json_to_bucket", fake_upload)
+
+    async with AsyncClient(app=app, base_url="http://test") as client:
+        async def call():
+            resp = await client.post(
+                "/analysis/face/heavy", json={"bucket": "b", "object_path": "p"}
+            )
+            assert resp.status_code == 200
+            assert resp.json()["ok"] is True
+
+        start = time.perf_counter()
+        await asyncio.gather(*[call() for _ in range(3)])
+        duration = time.perf_counter() - start
+
+    # If calls were processed sequentially, duration would be ~0.6s.
+    # Allow generous upper bound to account for CI variability.
+    assert duration < 0.5


### PR DESCRIPTION
## Summary
- Run Supabase download and face analysis in thread pool
- Add concurrency test for face analysis endpoint

## Testing
- `pytest tests/test_analysis_concurrency.py -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689bb519cc48832ea50a7e09d7cf222c